### PR TITLE
Remove usage of extensions library for BlazorStorage as more reliable…

### DIFF
--- a/src/BlazorState.Redux.Storage/BlazorState.Redux.Storage.csproj
+++ b/src/BlazorState.Redux.Storage/BlazorState.Redux.Storage.csproj
@@ -43,7 +43,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Blazor.Extensions.Storage" Version="1.0.0" />
+    <PackageReference Include="BlazorStorage" Version="1.0.0" />
     <PackageReference Include="Nerdbank.GitVersioning" Version="3.0.28">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/BlazorState.Redux.Storage/LocalStorageProvider.cs
+++ b/src/BlazorState.Redux.Storage/LocalStorageProvider.cs
@@ -1,7 +1,7 @@
 ﻿using System.Text.Json;
 using System.Threading.Tasks;
-using Blazor.Extensions.Storage;
 using BlazorState.Redux.Interfaces;
+using BlazorStorage.Interfaces;
 using Newtonsoft.Json;
 
 namespace BlazorState.Redux.Storage
@@ -9,9 +9,9 @@ namespace BlazorState.Redux.Storage
     public class LocalStorageProvider : IStateStorage
     {
         private readonly string _key;
-        private readonly LocalStorage _storage;
+        private readonly ILocalStorage _storage;
 
-        public LocalStorageProvider(string key, LocalStorage storage)
+        public LocalStorageProvider(string key, ILocalStorage storage)
         {
             _key = key;
             _storage = storage;

--- a/src/BlazorState.Redux.Storage/ReduxStoreConfigExtensions.cs
+++ b/src/BlazorState.Redux.Storage/ReduxStoreConfigExtensions.cs
@@ -1,7 +1,8 @@
 ﻿using System.Linq;
-using Blazor.Extensions.Storage;
 using BlazorState.Redux.Configuration;
 using BlazorState.Redux.Interfaces;
+using BlazorStorage.Extensions;
+using BlazorStorage.Interfaces;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace BlazorState.Redux.Storage
@@ -17,8 +18,8 @@ namespace BlazorState.Redux.Storage
                 config.Services.Remove(storageRegistration);
             }
 
-            config.Services.AddSingleton<LocalStorage>();
-            config.Services.AddSingleton<IStateStorage>(s => new LocalStorageProvider(key, s.GetService<LocalStorage>()));
+            config.Services.AddStorage();
+            config.Services.AddSingleton<IStateStorage>(s => new LocalStorageProvider(key, s.GetService<ILocalStorage>()));
         }
     }
 }

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 ﻿{
-  "version": "1.0.3",
+  "version": "1.0.4",
   "publicReleaseRefSpec": [
     "^refs/heads/master$",
     "^refs/heads/v\\d+(?:\\.\\d+)?$"


### PR DESCRIPTION
better way to access browser's local storage.

Bump version to 1.0.4